### PR TITLE
add tomlrt and tomledit to the benchmarks

### DIFF
--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -12,9 +12,11 @@ import qtoml
 import rtoml
 import toml
 import toml_rs
+import tomledit
 import tomli as tomllib
 import tomli_w
 import tomlkit
+import tomlrt
 
 N = 500
 
@@ -128,16 +130,20 @@ def run(run_count: int) -> None:
         "pytomlpp": lambda: pytomlpp.loads(data),
         "tomllib": lambda: tomllib.loads(data),
         "toml": lambda: toml.loads(data),
+        "tomledit": lambda: tomledit.loads(data),
         "qtoml": lambda: qtoml.loads(fixed_data),
         "tomlkit": lambda: tomlkit.parse(data),
+        "tomlrt": lambda: tomlrt.loads(data),
     }
     dumps = {
         "toml_rs": lambda: toml_rs.dumps(obj, toml_version="1.1.0"),
         "rtoml": lambda: rtoml.dumps(obj),
         "pytomlpp": lambda: pytomlpp.dumps(obj),
         "toml": lambda: toml.dumps(obj),
+        "tomledit": lambda: tomledit.dumps(obj),
         "qtoml": lambda: qtoml.dumps(obj),
         "tomlkit": lambda: tomlkit.dumps(obj),
+        "tomlrt": lambda: tomlrt.dumps(obj),
         "tomli-w": lambda: tomli_w.dumps(obj),
     }
     loads = {name: benchmark(func, run_count) for name, func in loads.items()}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,9 @@ dev = [
 bench = [
     "pytomlpp",
     "toml",
+    "tomledit",
     "tomlkit",
+    "tomlrt",
     "qtoml",
     "rtoml",
     { include-group = "tomli-1-1" },
@@ -109,4 +111,3 @@ conflicts = [[
 ]]
 
 dependency-groups.wasm-test = { requires-python = ">= 3.13" }
-


### PR DESCRIPTION
No idea whether you are interested in updating the benchmark with new players: but in case you are...

`tomledit` is a wrapper around the rust toml-edit, bringing its format-preserving capabilities.

`tomlrt` is a pure python implementation, also format-preserving.  (Partly because I found that I could not wrap toml-edit without some parts of the API getting a bit awkward; and partly because I thought it would be interesting to see how the LLMs did on the task).

---

A couple of thoughts on the benchmarks...

First: `qtoml` last had a release in 2021.  Per the readme "qTOML is now deprecated. It will not be updated further".  Suggest removing it.

Second: the dump benchmark is certainly testing a legitimate thing: dumping a plain python dictionary.  But there is a reasonable argument that this is - not unfair but unhelpful - for users of libraries where the plain python dictionary is not their primary representation.

For instance, the primary use case for preferring a format-preserving library like tomlkit is: `doc = tomlkit.loads(text) ; edit the doc ; text = tomlkit.dumps(doc)`

ie the thing that tomlkit users usually dump is not a plain python dictionary, it is a tomlkit document.  The benchmark is counting the cost both of converting a plain python dictionary to a document, and also of dumping the document - and the first is not a typical thing to do.

I don't have a strong opinion on whether this matters enough to do anything about it.  Could reasonably update the existing benchmark to start by loading with the library under test; or could add a third benchmark; or could do nothing at all.