### PR TITLE
fix `dumps()` returning an empty string for lists

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,6 +1,6 @@
 # To run the benchmarks
 
-## Create and activate virtual environment
+## Create and activate a virtual environment
 
 <p>
   <span style="white-space: nowrap;">
@@ -83,6 +83,29 @@ python benchmark/run.py
 ```
 
 ## Results
+
+> [!NOTE]
+> The dump benchmark serializes a plain Python `dict`.
+> This is representative of libraries whose primary representation
+> is a Python dict, but may not fully reflect the typical
+> workflow of a format-preserving library, for example `tomlkit`.
+>
+> A typical code with `tomlkit` looks like:
+>
+> ```python
+> import tomlkit
+>
+> doc = tomlkit.parse(text)
+> # edit doc
+> text = tomlkit.dumps(doc)
+> ```
+>
+> In this case, dumping an already-parsed document does not include
+> the cost of converting a plain Python dictionary into the library's
+> internal representation. Therefore, the dump benchmark should be
+> interpreted as a benchmark of **Python dict -> TOML
+> serialization**, rather than a complete benchmark of
+> format-preserving document editing.
 
 Benchmarks are updated daily and stored in [this](https://github.com/lava-sh/benchmarks/tree/main/toml-rs) repository.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,10 @@ mod toml_rs {
     import_exception!(toml_rs, TOMLDecodeError);
     import_exception!(toml_rs, TOMLEncodeError);
 
-    #[pyfunction(name = "_loads")]
+    #[pyfunction(
+        name = "_loads",
+        signature = (toml_string, /, *, parse_float, toml_version),
+    )]
     fn load_toml_from_string(
         py: Python,
         toml_string: &str,
@@ -83,12 +86,15 @@ mod toml_rs {
     }
 
     #[expect(clippy::needless_pass_by_value)]
-    #[pyfunction(name = "_dumps")]
+    #[pyfunction(
+        name = "_dumps",
+        signature = (obj, /, inline_tables=None, *, pretty=false, toml_version),
+    )]
     fn dumps_toml(
         py: Python,
         obj: &Bound<'_, PyAny>,
-        pretty: bool,
         inline_tables: Option<FxHashSet<String>>,
+        pretty: bool,
         toml_version: &str,
     ) -> PyResult<String> {
         match toml_version {
@@ -102,9 +108,13 @@ mod toml_rs {
 
                 let mut doc = DocumentMut::new();
 
-                if let Table(table) = python_to_toml(py, obj, inline_tables.as_ref())? {
-                    *doc.as_table_mut() = table;
-                }
+                let Table(table) = python_to_toml(py, obj, inline_tables.as_ref())? else {
+                    return Err(TOMLEncodeError::new_err(format!(
+                        "Cannot serialize {} to TOML",
+                        crate::get_type!(obj),
+                    )));
+                };
+                *doc.as_table_mut() = table;
 
                 if let Some(ref paths) = inline_tables {
                     validate_inline_paths(doc.as_item(), paths)?;
@@ -126,9 +136,13 @@ mod toml_rs {
 
                 let mut doc = DocumentMut::new();
 
-                if let Table(table) = python_to_toml(py, obj, inline_tables.as_ref())? {
-                    *doc.as_table_mut() = table;
-                }
+                let Table(table) = python_to_toml(py, obj, inline_tables.as_ref())? else {
+                    return Err(TOMLEncodeError::new_err(format!(
+                        "Cannot serialize {} to TOML",
+                        crate::get_type!(obj),
+                    )));
+                };
+                *doc.as_table_mut() = table;
 
                 if let Some(ref paths) = inline_tables {
                     validate_inline_paths(doc.as_item(), paths)?;
@@ -146,7 +160,10 @@ mod toml_rs {
         }
     }
 
-    #[pyfunction(name = "_parse_metadata_from_string")]
+    #[pyfunction(
+        name = "_parse_metadata_from_string",
+        signature = (toml_string, /, *, toml_version),
+    )]
     fn parse_metadata_from_string(
         py: Python,
         toml_string: &str,

--- a/tests/test_dumps.py
+++ b/tests/test_dumps.py
@@ -36,6 +36,21 @@ class MyMap(Mapping[str, Any]):
             {},
         ),
         (
+            None,
+            re.escape("Cannot serialize None (<class 'NoneType'>) to TOML"),
+            {},
+        ),
+        (
+            [],
+            re.escape("Cannot serialize [] (<class 'list'>) to TOML"),
+            {},
+        ),
+        (
+            [1, 2],
+            re.escape("Cannot serialize [1, 2] (<class 'list'>) to TOML"),
+            {},
+        ),
+        (
             {"x": lambda x: x},
             r"Cannot serialize <function <lambda> at 0x.*> \(<class 'function'>\)",
             {},


### PR DESCRIPTION
Fixes: #270 